### PR TITLE
feat: add custom ports and reader dispatch extensions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,15 +44,20 @@ src/
   managed.rs   — ThreadLocalContext: persistent/fresh managed context on dedicated thread
   sandbox.rs   — Preset type, FsPolicy, ModulePolicy, 16 const preset definitions for env restriction
   thread.rs    — shared channel protocol (Request, Response, SendableValue, ForeignFnPtr)
+  port.rs     — PortStore: Read/Write bridge via thread-local trampoline (custom ports)
   timeout.rs   — TimeoutContext: wall-clock timeout via dedicated thread
 vendor/chibi-scheme/
   tein_shim.c  — exports chibi c macros as real functions, fuel control, env manipulation,
                  env_copy_named (rename-aware binding copy), error construction,
-                 module import policy (tein_module_allowed, tein_module_policy_set)
+                 module import policy (tein_module_allowed, tein_module_policy_set),
+                 custom port creation, reader dispatch table (set/unset/get/chars/clear/reserved)
   eval.c       — 3 patches: VFS module lookup (A + module policy gate), VFS load (B), VFS open-input-file (C)
+  sexp.c       — 1 patch: reader dispatch table check before hardcoded # switch
   vm.c         — 2-line patch for fuel budget consumption at timeslice boundary
   lib/tein/foreign.sld — (tein foreign) library definition
   lib/tein/foreign.scm — pure-scheme predicates: foreign?, foreign-type, foreign-handle-id
+  lib/tein/reader.sld — (tein reader) library definition (re-exports native dispatch fns)
+  lib/tein/reader.scm — module documentation
 build.rs       — compiles chibi + shim, generates install.h, tein_vfs_data.h, tein_clibs.c
 examples/      — basic.rs, floats.rs, ffi.rs, debug.rs, sandbox.rs, foreign_types.rs
 ```
@@ -70,6 +75,10 @@ examples/      — basic.rs, floats.rs, ffi.rs, debug.rs, sandbox.rs, foreign_ty
 **foreign type protocol flow**: `ctx.register_foreign_type::<T>()` → registers `ForeignType::methods()` in `ForeignStore` → injects `foreign-call`/`foreign-types`/`foreign-methods`/`foreign-type-methods` as native fns + pure-scheme `foreign?`/`foreign-type`/`foreign-handle-id` → auto-generates `type-name?` and `type-name-method` convenience procs. `ctx.foreign_value(v)` → inserts into store → returns `Value::Foreign { handle_id, type_name }`. scheme calls `(type-name-method obj)` → convenience proc → `(apply foreign-call obj 'method args)` → `foreign_call_wrapper` (extern "C") → reads `FOREIGN_STORE_PTR` thread-local → `dispatch_foreign_call` → looks up method by type name + method name → calls `MethodFn` with `&mut dyn Any` → returns `Value`. `FOREIGN_STORE_PTR` is set by `evaluate()`/`call()` via `ForeignStoreGuard` RAII.
 
 **managed context flow**: `ContextBuilder::build_managed(init)` → spawns dedicated thread → builds Context on that thread → runs init closure → signals ready. subsequent `evaluate()`/`call()` → send `Request` over channel → thread processes → sends `Response` back. `reset()` → sends `Request::Reset` → thread rebuilds context + reruns init. `build_managed_fresh()` → same, but rebuilds before every evaluation (no state leakage).
+
+**custom port flow**: `ctx.open_input_port(reader)` → inserts `Box<dyn Read>` into `PortStore` → creates scheme closure `(lambda (buf start end) (tein-port-read ID buf start end))` → `ffi::make_custom_input_port(ctx, closure)` → chibi's `fopencookie` + `sexp_cookie_reader` calls closure on buffer fill → `port_read_trampoline` (extern "C") reads from `PORT_STORE_PTR` thread-local → copies bytes into scheme string buffer → returns fixnum byte count. output ports mirror via `port_write_trampoline`. `ctx.read(&port)` calls `sexp_read` for one s-expression; `ctx.evaluate_port(&port)` loops read+eval.
+
+**reader dispatch flow**: `ctx.register_reader('j', &handler)` or scheme `(set-reader! #\j handler)` → `ffi::reader_dispatch_set(c, proc)` → stores proc in thread-local `tein_reader_dispatch[128]` table. when chibi's reader encounters `#j`, patched `sexp.c` calls `tein_reader_dispatch_get(c1)` → finds handler → `sexp_apply1(ctx, handler, in)` → handler receives input port, reads further if needed, returns datum → reader returns datum to evaluator. `register_reader_protocol` registers `set-reader!`/`unset-reader!`/`reader-dispatch-chars` as native fns in `build()` for standard env contexts. dispatch table cleared on `Context::drop()`. reserved r7rs chars (`#t`, `#f`, `#\`, `#(`, numeric prefixes, etc.) cannot be overridden.
 
 **thread safety**: Context is intentionally !Send + !Sync. chibi contexts are not thread-safe. one context per thread. TimeoutContext wraps a Context on a dedicated thread for wall-clock deadlines. ThreadLocalContext generalises this pattern with persistent/fresh modes. fuel counters are thread-local.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -311,3 +311,62 @@ RAII, ensuring the pointer is always valid during scheme execution and cleared o
 - `foreign-handle-id` — returns the handle ID fixnum
 
 uses `car`/`cdr` chains instead of `cadr`/`caddr` (those require `scheme/cxr`).
+
+## custom port protocol
+
+bridges rust `Read`/`Write` objects to chibi's custom port mechanism via thread-local trampoline — same pattern as ForeignStore.
+
+### architecture
+
+- **PortStore** (`port.rs`): per-context map from port ID → `Box<dyn Read>` or `Box<dyn Write>`
+- **PORT_STORE_PTR** (`context.rs`): thread-local raw pointer, set before evaluate/call via `PortStoreGuard` RAII
+- **port_read_trampoline** / **port_write_trampoline**: extern "C" fns called by chibi's `sexp_cookie_reader`/`writer` via `fopencookie`
+
+### creating ports
+
+```rust
+let port = ctx.open_input_port(std::io::Cursor::new(b"(+ 1 2)"))?;
+let val = ctx.read(&port)?;           // read one s-expression
+let result = ctx.evaluate_port(&port)?; // read+eval loop
+```
+
+output ports work similarly via `open_output_port`. pass the port value to scheme's `display`/`write`/`write-char`.
+
+### chibi protocol details
+
+- read callback receives `(buf start end)` where `buf[0..start)` has valid data from prior partial fills
+- return value must be `start + new_bytes_read` (chibi copies from position 0)
+- `flush-output` is the primitive name; `flush-output-port` requires `(scheme extras)`
+
+## reader dispatch protocol
+
+extends chibi's `#` reader syntax with user-defined handlers via a C-level dispatch table.
+
+### architecture
+
+- **tein_reader_dispatch[128]** (`tein_shim.c`): thread-local table mapping ASCII chars → scheme procs
+- **sexp.c patch**: reader checks dispatch table before hardcoded `#` switch — `tein_reader_dispatch_get(c1)` → `sexp_apply1` if handler found
+- **register_reader_protocol** (`context.rs`): registers `set-reader!`/`unset-reader!`/`reader-dispatch-chars` as native fns, always called in `build()` for standard env contexts
+- **(tein reader)** VFS module: re-exports native fns for idiomatic `(import (tein reader))` usage
+
+### usage
+
+```rust
+// from rust
+let handler = ctx.evaluate("(lambda (port) 42)")?;
+ctx.register_reader('j', &handler)?;
+assert_eq!(ctx.evaluate("#j")?, Value::Integer(42));
+```
+
+```scheme
+;; from scheme (fns available directly in standard env)
+(set-reader! #\j (lambda (port) (list 'json (read port))))
+;; #j(1 2 3) → (json (1 2 3))
+```
+
+### design notes
+
+- reserved r7rs chars (`#t`, `#f`, `#\`, `#(`, numeric prefixes, etc.) cannot be overridden
+- dispatch table is thread-local, matching chibi's !Send context model
+- table cleared on `Context::drop()` so next context on the thread starts clean
+- handler return value becomes the reader result — gets evaluated by `evaluate()`, so return self-evaluating datums (numbers, strings, lists) or use `read()` for raw datum access

--- a/TODO.md
+++ b/TODO.md
@@ -78,7 +78,16 @@
 - [ ] **WASM target** — chibi compiles via emscripten
 - [x] **serde data format** — s-expression ↔ rust structs via tein-sexp (hardened: alist fix, Sexp value type, IO API, attribute compat)
 - [ ] **macro expansion hooks**
-- [ ] **custom reader extensions**
+- [x] **custom ports** — rust `Read`/`Write` as scheme input/output ports
+  - `open_input_port`/`open_output_port` → `PortStore` + thread-local trampoline
+  - `read()` for single s-expression, `evaluate_port()` for read+eval loop
+  - chibi's `fopencookie` + `sexp_cookie_reader`/`writer` callback protocol
+- [x] **custom reader extensions**
+  - `#x` hash dispatch via C-level thread-local table + patched sexp.c reader
+  - `set-reader!`/`unset-reader!`/`reader-dispatch-chars` in standard env
+  - `(tein reader)` VFS module for idiomatic imports
+  - `Context::register_reader(char, &Value)` rust convenience API
+  - reserved r7rs char protection, dispatch table cleared on context drop
 
 ### milestone 6 — foreign type protocol
 

--- a/docs/plans/2026-02-23-reader-extensions-handoff.md
+++ b/docs/plans/2026-02-23-reader-extensions-handoff.md
@@ -1,0 +1,94 @@
+# reader extensions handoff
+
+## context
+
+implementing custom ports + hash dispatch reader extensions for tein. working in worktree `.worktrees/reader-extensions` on branch `feature/reader-extensions`.
+
+**reference docs:**
+- design: `docs/plans/2026-02-23-reader-extensions-design.md`
+- implementation plan: `~/.claude-mani/plans/woolly-wobbling-stearns.md`
+
+## status: tasks 1-9 complete (of 15), uncommitted
+
+all changes are staged-ready but **not committed** — the plan calls for per-task commits. you can either commit them individually with the messages below or squash into feature commits per your preference.
+
+### what's done
+
+**feature 1: custom ports — fully working + tested + documented**
+
+| task | description | suggested commit |
+|------|-------------|-----------------|
+| 1 | PortStore scaffolding (`src/port.rs`, wired into Context) | `feat: add PortStore scaffolding for custom ports` |
+| 2 | C shim + FFI for `sexp_make_custom_input_port`/`output_port` | `feat: add C shim + FFI for custom port creation` |
+| 3 | read trampoline + `open_input_port()` + test | `feat: add read trampoline + open_input_port for custom ports` |
+| 4 | `Context::read()` — read one s-expression from a port | `feat: add Context::read() for reading s-expressions from ports` |
+| 5 | `Context::evaluate_port()` — read+eval loop from a port | `feat: add Context::evaluate_port() for read+eval from ports` |
+| 6 | write trampoline + `open_output_port()` + test | `feat: add output port support (write trampoline + open_output_port)` |
+| 7 | edge case tests: multi-sexp read, `input-port?`, scheme `read`, EOF | `test: add edge case tests for custom ports` |
+| 8 | docs: AGENTS.md (port.rs + custom port flow), DEVELOPMENT.md (custom port protocol) | `docs: add custom port architecture to AGENTS.md and DEVELOPMENT.md` |
+
+**feature 2: hash dispatch reader extensions — C layer done**
+
+| task | description | suggested commit |
+|------|-------------|-----------------|
+| 9 | C dispatch table: `tein_reader_dispatch[128]`, set/unset/get/chars/clear, reserved char check | `feat: add reader dispatch table to tein_shim.c` |
+
+**modified files (cumulative):**
+- `tein/src/port.rs` (NEW) — PortStore with reader/writer map
+- `tein/src/lib.rs` — added `mod port;`
+- `tein/src/context.rs` — PORT_STORE_PTR thread-local, PortStoreGuard, read/write trampolines, `register_port_protocol`, `open_input_port`, `open_output_port`, `read`, `evaluate_port`, 9 tests, 3 doctests
+- `tein/src/ffi.rs` — extern decls + safe wrappers for `tein_make_custom_input_port`/`output_port`
+- `tein/vendor/chibi-scheme/tein_shim.c` — custom port wrappers + reader dispatch table (set/unset/get/chars/clear/reserved)
+- `AGENTS.md` — added port.rs to architecture, custom port data flow
+- `DEVELOPMENT.md` — added custom port protocol section
+
+**test counts:** 174 lib (was 165) + 13 doctests (was 9). all passing, clippy clean, fmt clean.
+
+### critical findings during implementation
+
+**1. chibi custom port read callback protocol**
+
+the read proc receives `(buf start end)` where `buf[0..start)` already has valid data from prior partial fills. the return value must be `start + new_bytes_read`, NOT just `new_bytes_read`. chibi does `memcpy(C_buffer, string_data(buf), result)` — copies from position 0.
+
+**2. chibi `flush-output-port` availability**
+
+`flush-output-port` is in `(scheme extras)`, not directly available in the standard env. chibi's primitive name is `flush-output`. the output port test uses `flush-output` to trigger the write callback.
+
+**3. plan deviations**
+
+- plan references `ffi::exception_message(ctx, result)` — this function doesn't exist. used the existing pattern of returning exceptions via `Value::from_raw()` instead.
+- plan says "no dedicated rust registration API" for reader dispatch (design doc line 85), but task 14 adds `register_reader()`. follow the plan — it's a good improvement.
+- plan says register reader protocol "always in build() for standard_env contexts" (task 12), but port protocol uses lazy registration with a flag. both patterns are fine, follow the plan for each.
+
+## what's left: tasks 10-15
+
+### feature 2: hash dispatch reader extensions (remaining)
+
+**task 10: patch sexp.c # dispatch** — patch `sexp.c` reader to check dispatch table before the hardcoded `#` switch. small surgical patch. verify line numbers in vendored copy (plan says ~3511-3512).
+
+**task 11: FFI bindings** — add extern decls + safe wrappers for the 6 dispatch table functions.
+
+**task 12: native dispatch fns + (tein reader) VFS module** — extern "C" wrappers (`reader_set_wrapper`, `reader_unset_wrapper`, `reader_chars_wrapper`), `register_reader_protocol`, create `lib/tein/reader.sld` + `reader.scm`, register in `build.rs` VFS_FILES. the big integration task.
+
+**task 13: reader dispatch tests** — reserved char rejection, handler that reads further from port, unset, introspection via `reader-dispatch-chars`, multi-char sub-dispatch.
+
+**task 14: rust-side `register_reader()` convenience API** — `Context::register_reader(char, &Value)` that calls `ffi::tein_reader_dispatch_set` directly. error on reserved chars.
+
+**task 15: final docs + cleanup** — update AGENTS.md with reader dispatch flow, update TODO.md, final `cargo test && cargo clippy && cargo fmt --check`.
+
+### important notes for tasks 10-15
+
+- the sexp.c patch location (line 3511-3512) should be verified — line numbers may differ in the vendored copy
+- reader dispatch state is thread-local (C-level), matching chibi's !Send context model
+- `register_reader_protocol` should always run for standard_env contexts per the plan (unlike port protocol's lazy init)
+- VFS module registration in build.rs follows the pattern at lines 68-70 (tein/foreign entries)
+- reader dispatch must be cleared on Context drop (add to Drop impl, similar to module policy cleanup)
+
+## how to continue
+
+```bash
+cd /home/fey/projects/tein/tein-dev/.worktrees/reader-extensions
+cargo test                  # verify green baseline (174 lib + 13 doc)
+```
+
+execute the implementation plan at `~/.claude-mani/plans/woolly-wobbling-stearns.md` starting from task 10. use the executing-plans skill. commit per the plan's suggested messages (or squash per preference). the plan has exact code for most tasks — follow it but watch for the gotchas documented above.

--- a/tein/build.rs
+++ b/tein/build.rs
@@ -68,6 +68,9 @@ const VFS_FILES: &[&str] = &[
     // tein foreign type protocol
     "lib/tein/foreign.sld",
     "lib/tein/foreign.scm",
+    // tein reader dispatch protocol
+    "lib/tein/reader.sld",
+    "lib/tein/reader.scm",
 ];
 
 /// C-backed modules that need static linking.

--- a/tein/src/context.rs
+++ b/tein/src/context.rs
@@ -5,6 +5,7 @@ use crate::{
     error::{Error, Result},
     ffi,
     foreign::{ForeignStore, ForeignType},
+    port::PortStore,
     sandbox::{FS_POLICY, FsPolicy, MODULE_POLICY, ModulePolicy, Preset},
 };
 use std::cell::{Cell, RefCell};
@@ -40,6 +41,25 @@ thread_local! {
             Cell::new(std::ptr::null_mut()),
         ]
     };
+}
+
+// --- port store thread-local for custom port trampolines ---
+//
+// set to &self.port_store before every evaluate()/call() invocation,
+// cleared afterwards. the extern "C" port trampolines read it to access
+// the backing Read/Write objects. safe because Context is !Send + !Sync
+// and the pointer is only live during evaluation.
+thread_local! {
+    static PORT_STORE_PTR: Cell<*const RefCell<PortStore>> = const { Cell::new(std::ptr::null()) };
+}
+
+/// RAII guard that clears the PORT_STORE_PTR thread-local on drop.
+struct PortStoreGuard;
+
+impl Drop for PortStoreGuard {
+    fn drop(&mut self) {
+        PORT_STORE_PTR.with(|c| c.set(std::ptr::null()));
+    }
 }
 
 // --- foreign store thread-local for dispatch wrappers ---
@@ -193,6 +213,192 @@ unsafe extern "C" fn foreign_type_methods_wrapper(
         }
         result
     }
+}
+
+// --- custom port trampolines ---
+
+/// extern "C" trampoline for custom input port reads.
+///
+/// called by chibi via sexp_apply when the custom port's buffer needs refilling.
+/// args from scheme: (port-id buffer start end).
+/// reads from the rust Read object in PortStore, copies bytes into the scheme
+/// string buffer, returns fixnum byte count.
+unsafe extern "C" fn port_read_trampoline(
+    _ctx: ffi::sexp,
+    _self: ffi::sexp,
+    _n: ffi::sexp_sint_t,
+    args: ffi::sexp,
+) -> ffi::sexp {
+    unsafe {
+        let id_sexp = ffi::sexp_car(args);
+        let rest = ffi::sexp_cdr(args);
+        let buf_sexp = ffi::sexp_car(rest);
+        let rest2 = ffi::sexp_cdr(rest);
+        let start_sexp = ffi::sexp_car(rest2);
+        let rest3 = ffi::sexp_cdr(rest2);
+        let end_sexp = ffi::sexp_car(rest3);
+
+        let port_id = ffi::sexp_unbox_fixnum(id_sexp) as u64;
+        let start = ffi::sexp_unbox_fixnum(start_sexp) as usize;
+        let end = ffi::sexp_unbox_fixnum(end_sexp) as usize;
+        let len = end - start;
+
+        let store_ptr = PORT_STORE_PTR.with(|c| c.get());
+        if store_ptr.is_null() {
+            return ffi::sexp_make_fixnum(0);
+        }
+        let store = &*store_ptr;
+        let mut store_ref = store.borrow_mut();
+        let reader = match store_ref.get_reader(port_id) {
+            Some(r) => r,
+            None => return ffi::sexp_make_fixnum(0),
+        };
+
+        let mut tmp = vec![0u8; len];
+        let bytes_read = match reader.read(&mut tmp) {
+            Ok(n) => n,
+            Err(_) => return ffi::sexp_make_fixnum(0),
+        };
+
+        let buf_data = ffi::sexp_string_data(buf_sexp) as *mut u8;
+        std::ptr::copy_nonoverlapping(tmp.as_ptr(), buf_data.add(start), bytes_read);
+
+        // return start + bytes_read: chibi copies [0..result) from the buffer,
+        // where [0..start) was already valid from a previous partial fill.
+        ffi::sexp_make_fixnum((start + bytes_read) as ffi::sexp_sint_t)
+    }
+}
+
+/// extern "C" trampoline for custom output port writes.
+///
+/// called by chibi via sexp_apply when data needs flushing to the port.
+/// args from scheme: (port-id buffer start end).
+/// writes bytes from the scheme string buffer to the rust Write object
+/// in PortStore, returns fixnum byte count.
+unsafe extern "C" fn port_write_trampoline(
+    _ctx: ffi::sexp,
+    _self: ffi::sexp,
+    _n: ffi::sexp_sint_t,
+    args: ffi::sexp,
+) -> ffi::sexp {
+    unsafe {
+        let id_sexp = ffi::sexp_car(args);
+        let rest = ffi::sexp_cdr(args);
+        let buf_sexp = ffi::sexp_car(rest);
+        let rest2 = ffi::sexp_cdr(rest);
+        let start_sexp = ffi::sexp_car(rest2);
+        let rest3 = ffi::sexp_cdr(rest2);
+        let end_sexp = ffi::sexp_car(rest3);
+
+        let port_id = ffi::sexp_unbox_fixnum(id_sexp) as u64;
+        let start = ffi::sexp_unbox_fixnum(start_sexp) as usize;
+        let end = ffi::sexp_unbox_fixnum(end_sexp) as usize;
+        let len = end - start;
+
+        let store_ptr = PORT_STORE_PTR.with(|c| c.get());
+        if store_ptr.is_null() {
+            return ffi::sexp_make_fixnum(0);
+        }
+        let store = &*store_ptr;
+        let mut store_ref = store.borrow_mut();
+        let writer = match store_ref.get_writer(port_id) {
+            Some(w) => w,
+            None => return ffi::sexp_make_fixnum(0),
+        };
+
+        let buf_data = ffi::sexp_string_data(buf_sexp) as *const u8;
+        let slice = std::slice::from_raw_parts(buf_data.add(start), len);
+        match writer.write(slice) {
+            Ok(n) => ffi::sexp_make_fixnum(n as ffi::sexp_sint_t),
+            Err(_) => ffi::sexp_make_fixnum(0),
+        }
+    }
+}
+
+/// extern "C" wrapper for `(tein-reader-set! char proc)`.
+///
+/// registers a reader dispatch handler for `#char` syntax. rejects reserved
+/// r7rs characters with a descriptive error.
+unsafe extern "C" fn reader_set_wrapper(
+    ctx: ffi::sexp,
+    _self: ffi::sexp,
+    _n: ffi::sexp_sint_t,
+    args: ffi::sexp,
+) -> ffi::sexp {
+    unsafe {
+        // args is a list: (char proc)
+        if ffi::sexp_nullp(args) != 0 {
+            let msg = "set-reader!: expected (set-reader! char proc)";
+            let c_msg = CString::new(msg).unwrap_or_default();
+            return ffi::make_error(ctx, c_msg.as_ptr(), msg.len() as ffi::sexp_sint_t);
+        }
+        let ch_sexp = ffi::sexp_car(args);
+        let rest = ffi::sexp_cdr(args);
+        if ffi::sexp_nullp(rest) != 0 {
+            let msg = "set-reader!: expected (set-reader! char proc)";
+            let c_msg = CString::new(msg).unwrap_or_default();
+            return ffi::make_error(ctx, c_msg.as_ptr(), msg.len() as ffi::sexp_sint_t);
+        }
+        let proc_sexp = ffi::sexp_car(rest);
+
+        if ffi::sexp_charp(ch_sexp) == 0 {
+            let msg = "set-reader!: first argument must be a character";
+            let c_msg = CString::new(msg).unwrap_or_default();
+            return ffi::make_error(ctx, c_msg.as_ptr(), msg.len() as ffi::sexp_sint_t);
+        }
+
+        let c = ffi::sexp_unbox_character(ch_sexp);
+        let result = ffi::reader_dispatch_set(c, proc_sexp);
+        match result {
+            0 => ffi::get_void(),
+            -1 => {
+                let ch = char::from(c as u8);
+                let msg = format!(
+                    "reader dispatch #{} is reserved by r7rs and cannot be overridden",
+                    ch
+                );
+                let c_msg = CString::new(msg.as_str()).unwrap_or_default();
+                ffi::make_error(ctx, c_msg.as_ptr(), msg.len() as ffi::sexp_sint_t)
+            }
+            _ => {
+                let msg = "set-reader!: character out of ASCII range";
+                let c_msg = CString::new(msg).unwrap_or_default();
+                ffi::make_error(ctx, c_msg.as_ptr(), msg.len() as ffi::sexp_sint_t)
+            }
+        }
+    }
+}
+
+/// extern "C" wrapper for `(tein-reader-unset! char)`.
+///
+/// removes a reader dispatch handler for `#char` syntax.
+unsafe extern "C" fn reader_unset_wrapper(
+    _ctx: ffi::sexp,
+    _self: ffi::sexp,
+    _n: ffi::sexp_sint_t,
+    args: ffi::sexp,
+) -> ffi::sexp {
+    unsafe {
+        let ch_sexp = ffi::sexp_car(args);
+        if ffi::sexp_charp(ch_sexp) == 0 {
+            return ffi::get_void();
+        }
+        let c = ffi::sexp_unbox_character(ch_sexp);
+        ffi::reader_dispatch_unset(c);
+        ffi::get_void()
+    }
+}
+
+/// extern "C" wrapper for `(tein-reader-dispatch-chars)`.
+///
+/// returns a list of characters with active dispatch handlers.
+unsafe extern "C" fn reader_chars_wrapper(
+    ctx: ffi::sexp,
+    _self: ffi::sexp,
+    _n: ffi::sexp_sint_t,
+    _args: ffi::sexp,
+) -> ffi::sexp {
+    unsafe { ffi::reader_dispatch_chars(ctx) }
 }
 
 /// the 4 file-opening primitives we wrap with policy checks
@@ -723,14 +929,25 @@ impl ContextBuilder {
                 }
             }
 
-            Ok(Context {
+            let context = Context {
                 ctx,
                 step_limit: self.step_limit,
                 has_io_wrappers: has_io,
                 has_module_policy,
                 foreign_store: RefCell::new(ForeignStore::new()),
                 has_foreign_protocol: Cell::new(false),
-            })
+                port_store: RefCell::new(PortStore::new()),
+                has_port_protocol: Cell::new(false),
+            };
+
+            // reader dispatch native fns are always registered for standard env
+            // contexts — cheap (3 fn registrations) and needed before any
+            // (import (tein reader)) can work.
+            if self.standard_env {
+                context.register_reader_protocol()?;
+            }
+
+            Ok(context)
         }
     }
 
@@ -783,6 +1000,10 @@ pub struct Context {
     foreign_store: RefCell<ForeignStore>,
     /// whether foreign protocol dispatch functions are registered
     has_foreign_protocol: Cell<bool>,
+    /// per-context store for custom port backing objects (Read/Write impls)
+    port_store: RefCell<PortStore>,
+    /// whether port protocol dispatch functions are registered
+    has_port_protocol: Cell<bool>,
 }
 
 impl Context {
@@ -870,10 +1091,12 @@ impl Context {
         let c_str = CString::new(code)
             .map_err(|_| Error::EvalError("code contains null bytes".to_string()))?;
 
-        // set foreign store pointer so dispatch wrappers can access it.
-        // the guard clears it on all exit paths (early returns, `?`, panic).
+        // set store pointers so dispatch wrappers and port trampolines can
+        // access them. guards clear on all exit paths (early returns, `?`, panic).
         FOREIGN_STORE_PTR.with(|c| c.set(&self.foreign_store as *const _));
         let _foreign_guard = ForeignStoreGuard;
+        PORT_STORE_PTR.with(|c| c.set(&self.port_store as *const _));
+        let _port_guard = PortStoreGuard;
         self.arm_fuel();
 
         unsafe {
@@ -1137,6 +1360,270 @@ impl Context {
         }))
     }
 
+    /// register the custom port protocol dispatch functions.
+    ///
+    /// called automatically by `open_input_port`/`open_output_port` on first use.
+    fn register_port_protocol(&self) -> Result<()> {
+        self.define_fn_variadic("tein-port-read", port_read_trampoline)?;
+        self.define_fn_variadic("tein-port-write", port_write_trampoline)?;
+        Ok(())
+    }
+
+    /// register native fns for reader dispatch protocol.
+    ///
+    /// called automatically by `build()` for standard env contexts. the native
+    /// fns (`tein-reader-set!` etc.) are used by the `(tein reader)` VFS module
+    /// to provide the public API (`set-reader!`, `unset-reader!`, etc.).
+    fn register_reader_protocol(&self) -> Result<()> {
+        self.define_fn_variadic("set-reader!", reader_set_wrapper)?;
+        self.define_fn_variadic("unset-reader!", reader_unset_wrapper)?;
+        self.define_fn_variadic("reader-dispatch-chars", reader_chars_wrapper)?;
+        Ok(())
+    }
+
+    /// register a reader dispatch handler for `#ch` syntax.
+    ///
+    /// the handler must be a scheme procedure taking one argument (the input
+    /// port) and returning a datum. reserved r7rs characters (`#t`, `#f`,
+    /// `#\\`, `#(`, numeric prefixes, etc.) cannot be overridden.
+    ///
+    /// # examples
+    ///
+    /// ```
+    /// use tein::{Context, Value};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let ctx = Context::new_standard()?;
+    /// let handler = ctx.evaluate("(lambda (port) 42)")?;
+    /// ctx.register_reader('j', &handler)?;
+    /// assert_eq!(ctx.evaluate("#j")?, Value::Integer(42));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn register_reader(&self, ch: char, handler: &Value) -> Result<()> {
+        let raw_proc = handler
+            .as_procedure()
+            .ok_or_else(|| Error::TypeError("handler must be a procedure".into()))?;
+        let c = ch as std::ffi::c_int;
+        unsafe {
+            let result = ffi::reader_dispatch_set(c, raw_proc);
+            match result {
+                0 => Ok(()),
+                -1 => Err(Error::EvalError(format!(
+                    "reader dispatch #{} is reserved by r7rs and cannot be overridden",
+                    ch
+                ))),
+                _ => Err(Error::EvalError("character out of ASCII range".into())),
+            }
+        }
+    }
+
+    /// wrap a rust `Read` as a scheme input port.
+    ///
+    /// returns a `Value::Port` that scheme code can pass to `read`,
+    /// `read-char`, `read-line`, etc. the backing `Read` lives in the
+    /// per-context `PortStore` until the context is dropped.
+    ///
+    /// # examples
+    ///
+    /// ```
+    /// use tein::{Context, Value};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let ctx = Context::new_standard()?;
+    /// let port = ctx.open_input_port(std::io::Cursor::new(b"42"))?;
+    /// assert!(port.is_port());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn open_input_port(&self, reader: impl std::io::Read + 'static) -> Result<Value> {
+        if !self.has_port_protocol.get() {
+            self.register_port_protocol()?;
+            self.has_port_protocol.set(true);
+        }
+
+        let port_id = self.port_store.borrow_mut().insert_reader(Box::new(reader));
+
+        // create scheme closure capturing port ID
+        let closure_code = format!(
+            "(lambda (buf start end) (tein-port-read {} buf start end))",
+            port_id
+        );
+
+        // need PORT_STORE_PTR set for the evaluate call
+        PORT_STORE_PTR.with(|c| c.set(&self.port_store as *const _));
+        let _guard = PortStoreGuard;
+
+        let read_proc_val = self.evaluate(&closure_code)?;
+        let raw_proc = read_proc_val
+            .as_procedure()
+            .ok_or_else(|| Error::EvalError("failed to create port read closure".into()))?;
+
+        unsafe {
+            let port = ffi::make_custom_input_port(self.ctx, raw_proc);
+            if ffi::sexp_exceptionp(port) != 0 {
+                return Err(Error::EvalError(
+                    "failed to create custom input port".into(),
+                ));
+            }
+            Value::from_raw(self.ctx, port)
+        }
+    }
+
+    /// wrap a rust `Write` as a scheme output port.
+    ///
+    /// returns a `Value::Port` that scheme code can pass to `write`,
+    /// `display`, `write-char`, etc. the backing `Write` lives in the
+    /// per-context `PortStore` until the context is dropped.
+    ///
+    /// # examples
+    ///
+    /// ```
+    /// use tein::{Context, Value};
+    /// use std::sync::{Arc, Mutex};
+    ///
+    /// struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+    /// impl std::io::Write for SharedWriter {
+    ///     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+    ///         self.0.lock().unwrap().extend_from_slice(buf);
+    ///         Ok(buf.len())
+    ///     }
+    ///     fn flush(&mut self) -> std::io::Result<()> { Ok(()) }
+    /// }
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    /// let ctx = Context::new_standard()?;
+    /// let port = ctx.open_output_port(SharedWriter(buf.clone()))?;
+    /// assert!(port.is_port());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn open_output_port(&self, writer: impl std::io::Write + 'static) -> Result<Value> {
+        if !self.has_port_protocol.get() {
+            self.register_port_protocol()?;
+            self.has_port_protocol.set(true);
+        }
+
+        let port_id = self.port_store.borrow_mut().insert_writer(Box::new(writer));
+
+        let closure_code = format!(
+            "(lambda (buf start end) (tein-port-write {} buf start end))",
+            port_id
+        );
+
+        PORT_STORE_PTR.with(|c| c.set(&self.port_store as *const _));
+        let _guard = PortStoreGuard;
+
+        let write_proc_val = self.evaluate(&closure_code)?;
+        let raw_proc = write_proc_val
+            .as_procedure()
+            .ok_or_else(|| Error::EvalError("failed to create port write closure".into()))?;
+
+        unsafe {
+            let port = ffi::make_custom_output_port(self.ctx, raw_proc);
+            if ffi::sexp_exceptionp(port) != 0 {
+                return Err(Error::EvalError(
+                    "failed to create custom output port".into(),
+                ));
+            }
+            Value::from_raw(self.ctx, port)
+        }
+    }
+
+    /// read one s-expression from a port.
+    ///
+    /// returns the parsed but unevaluated expression.
+    /// returns `Value::Unspecified` at end-of-input (EOF).
+    ///
+    /// # examples
+    ///
+    /// ```
+    /// use tein::{Context, Value};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let ctx = Context::new_standard()?;
+    /// let port = ctx.open_input_port(std::io::Cursor::new(b"42"))?;
+    /// let val = ctx.read(&port)?;
+    /// assert_eq!(val, Value::Integer(42));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn read(&self, port: &Value) -> Result<Value> {
+        let raw_port = port
+            .as_port()
+            .ok_or_else(|| Error::TypeError(format!("expected port, got {}", port)))?;
+
+        PORT_STORE_PTR.with(|c| c.set(&self.port_store as *const _));
+        let _port_guard = PortStoreGuard;
+        FOREIGN_STORE_PTR.with(|c| c.set(&self.foreign_store as *const _));
+        let _foreign_guard = ForeignStoreGuard;
+
+        unsafe {
+            let result = ffi::sexp_read(self.ctx, raw_port);
+            if ffi::sexp_eofp(result) != 0 {
+                return Ok(Value::Unspecified);
+            }
+            if ffi::sexp_exceptionp(result) != 0 {
+                return Value::from_raw(self.ctx, result);
+            }
+            Value::from_raw(self.ctx, result)
+        }
+    }
+
+    /// read and evaluate all expressions from a port.
+    ///
+    /// reads s-expressions one at a time, evaluating each in sequence.
+    /// returns the result of the last expression evaluated, or
+    /// `Value::Unspecified` if the port was empty.
+    ///
+    /// # examples
+    ///
+    /// ```
+    /// use tein::{Context, Value};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let ctx = Context::new_standard()?;
+    /// let port = ctx.open_input_port(std::io::Cursor::new(b"(define x 10) (+ x 5)"))?;
+    /// let result = ctx.evaluate_port(&port)?;
+    /// assert_eq!(result, Value::Integer(15));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn evaluate_port(&self, port: &Value) -> Result<Value> {
+        let raw_port = port
+            .as_port()
+            .ok_or_else(|| Error::TypeError(format!("expected port, got {}", port)))?;
+
+        PORT_STORE_PTR.with(|c| c.set(&self.port_store as *const _));
+        let _port_guard = PortStoreGuard;
+        FOREIGN_STORE_PTR.with(|c| c.set(&self.foreign_store as *const _));
+        let _foreign_guard = ForeignStoreGuard;
+        self.arm_fuel();
+
+        unsafe {
+            let env = ffi::sexp_context_env(self.ctx);
+            let mut last = Value::Unspecified;
+
+            loop {
+                let expr = ffi::sexp_read(self.ctx, raw_port);
+                if ffi::sexp_eofp(expr) != 0 {
+                    break;
+                }
+                if ffi::sexp_exceptionp(expr) != 0 {
+                    return Value::from_raw(self.ctx, expr);
+                }
+                let result = ffi::sexp_evaluate(self.ctx, expr, env);
+                self.check_fuel()?;
+                if ffi::sexp_exceptionp(result) != 0 {
+                    return Value::from_raw(self.ctx, result);
+                }
+                last = Value::from_raw(self.ctx, result)?;
+            }
+            Ok(last)
+        }
+    }
+
     /// register the foreign object protocol dispatch functions.
     ///
     /// called automatically by `register_foreign_type` on first use.
@@ -1204,6 +1691,8 @@ impl Context {
 
         FOREIGN_STORE_PTR.with(|c| c.set(&self.foreign_store as *const _));
         let _foreign_guard = ForeignStoreGuard;
+        PORT_STORE_PTR.with(|c| c.set(&self.port_store as *const _));
+        let _port_guard = PortStoreGuard;
         self.arm_fuel();
 
         unsafe {
@@ -1262,6 +1751,10 @@ impl Drop for Context {
                 }
             });
         }
+
+        // clear reader dispatch table so the next context on this thread
+        // starts with a clean slate (dispatch state is thread-local in C)
+        unsafe { ffi::reader_dispatch_clear() };
 
         unsafe {
             if !self.ctx.is_null() {
@@ -4058,5 +4551,258 @@ mod tests {
             .unwrap();
         drop(ctx);
         // no panic, no leaked thread — success
+    }
+
+    // --- custom ports ---
+
+    #[test]
+    fn test_open_input_port_basic() {
+        let ctx = Context::new_standard().expect("context");
+        let reader = std::io::Cursor::new(b"(+ 1 2)");
+        let port = ctx.open_input_port(reader);
+        assert!(port.is_ok(), "open_input_port should succeed");
+        assert!(port.unwrap().is_port(), "should return a Port value");
+    }
+
+    #[test]
+    fn test_read_from_custom_port() {
+        let ctx = Context::new_standard().expect("context");
+        let reader = std::io::Cursor::new(b"42");
+        let port = ctx.open_input_port(reader).expect("open port");
+        let val = ctx.read(&port).expect("read");
+        assert_eq!(val, Value::Integer(42));
+    }
+
+    #[test]
+    fn test_evaluate_port_single() {
+        let ctx = Context::new_standard().expect("context");
+        let port = ctx
+            .open_input_port(std::io::Cursor::new(b"(+ 1 2)"))
+            .expect("port");
+        let result = ctx.evaluate_port(&port).expect("eval");
+        assert_eq!(result, Value::Integer(3));
+    }
+
+    #[test]
+    fn test_evaluate_port_multiple() {
+        let ctx = Context::new_standard().expect("context");
+        let port = ctx
+            .open_input_port(std::io::Cursor::new(b"(define x 10) (+ x 5)"))
+            .expect("port");
+        let result = ctx.evaluate_port(&port).expect("eval");
+        assert_eq!(result, Value::Integer(15));
+    }
+
+    #[test]
+    fn test_evaluate_port_empty() {
+        let ctx = Context::new_standard().expect("context");
+        let port = ctx
+            .open_input_port(std::io::Cursor::new(b""))
+            .expect("port");
+        let result = ctx.evaluate_port(&port).expect("eval");
+        assert_eq!(result, Value::Unspecified);
+    }
+
+    #[test]
+    fn test_output_port_write() {
+        use std::sync::{Arc, Mutex};
+
+        struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+        impl std::io::Write for SharedWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let ctx = Context::new_standard().expect("context");
+        let port = ctx
+            .open_output_port(SharedWriter(buf.clone()))
+            .expect("port");
+
+        ctx.call(
+            &ctx.evaluate("display").expect("display"),
+            &[Value::String("hello".into()), port.clone()],
+        )
+        .expect("display call");
+
+        // flush to ensure buffered output is written to the custom port.
+        // chibi's primitive is flush-output; flush-output-port is in (scheme extras).
+        ctx.call(&ctx.evaluate("flush-output").expect("flush"), &[port])
+            .expect("flush");
+
+        let output = buf.lock().unwrap();
+        assert_eq!(&*output, b"hello");
+    }
+
+    #[test]
+    fn test_port_read_multiple_sexps() {
+        let ctx = Context::new_standard().expect("context");
+        let port = ctx
+            .open_input_port(std::io::Cursor::new(b"1 2 3"))
+            .expect("port");
+        assert_eq!(ctx.read(&port).unwrap(), Value::Integer(1));
+        assert_eq!(ctx.read(&port).unwrap(), Value::Integer(2));
+        assert_eq!(ctx.read(&port).unwrap(), Value::Integer(3));
+        assert_eq!(ctx.read(&port).unwrap(), Value::Unspecified); // EOF
+    }
+
+    #[test]
+    fn test_port_recognized_by_scheme() {
+        let ctx = Context::new_standard().expect("context");
+        let port = ctx
+            .open_input_port(std::io::Cursor::new(b"42"))
+            .expect("port");
+        let is_port = ctx
+            .call(&ctx.evaluate("input-port?").expect("fn"), &[port])
+            .expect("call");
+        assert_eq!(is_port, Value::Boolean(true));
+    }
+
+    #[test]
+    fn test_port_scheme_read() {
+        let ctx = Context::new_standard().expect("context");
+        let port = ctx
+            .open_input_port(std::io::Cursor::new(b"(list 1 2 3)"))
+            .expect("port");
+        let read_fn = ctx.evaluate("read").expect("read fn");
+        let expr = ctx
+            .call(&read_fn, std::slice::from_ref(&port))
+            .expect("read");
+        // expr is unevaluated: (list 1 2 3)
+        let result = ctx
+            .call(&ctx.evaluate("eval").expect("eval"), &[expr])
+            .expect("eval");
+        assert_eq!(
+            result,
+            Value::List(vec![
+                Value::Integer(1),
+                Value::Integer(2),
+                Value::Integer(3)
+            ])
+        );
+    }
+
+    // --- reader dispatch tests ---
+
+    #[test]
+    fn test_reader_dispatch_basic() {
+        let ctx = Context::new_standard().expect("context");
+        // reader dispatch fns are registered in standard env by build(),
+        // available directly or via (import (tein reader)).
+        // handler returns a self-evaluating value (number).
+        ctx.evaluate("(set-reader! #\\j (lambda (port) 42))")
+            .expect("set-reader");
+        let result = ctx.evaluate("#j").expect("eval #j");
+        assert_eq!(result, Value::Integer(42));
+    }
+
+    #[test]
+    fn test_reader_dispatch_reserved_char() {
+        let ctx = Context::new_standard().expect("context");
+        let result = ctx.evaluate("(set-reader! #\\t (lambda (port) 42))");
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(msg.contains("reserved"), "expected 'reserved' in: {}", msg);
+    }
+
+    #[test]
+    fn test_reader_dispatch_handler_reads_port() {
+        // handler reads further from the input port (the #j syntax consumes
+        // more input). use read() to inspect the raw datum — the handler
+        // returns a list, which evaluate() would try to call as a procedure.
+        let ctx = Context::new_standard().expect("context");
+        ctx.evaluate("(set-reader! #\\j (lambda (port) (list 'json (read port))))")
+            .expect("set");
+        let port = ctx
+            .open_input_port(std::io::Cursor::new(b"#j(1 2 3)"))
+            .expect("port");
+        let result = ctx.read(&port).expect("read");
+        let list = result.as_list().expect("list");
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0], Value::Symbol("json".into()));
+    }
+
+    #[test]
+    fn test_reader_dispatch_unset() {
+        let ctx = Context::new_standard().expect("context");
+        ctx.evaluate("(set-reader! #\\j (lambda (port) 42))")
+            .expect("set");
+        assert_eq!(ctx.evaluate("#j").unwrap(), Value::Integer(42));
+        ctx.evaluate("(unset-reader! #\\j)").expect("unset");
+        assert!(ctx.evaluate("#j").is_err());
+    }
+
+    #[test]
+    fn test_reader_dispatch_chars_introspection() {
+        let ctx = Context::new_standard().expect("context");
+        ctx.evaluate("(set-reader! #\\j (lambda (port) 42))")
+            .expect("set j");
+        ctx.evaluate("(set-reader! #\\p (lambda (port) 42))")
+            .expect("set p");
+        let chars = ctx.evaluate("(reader-dispatch-chars)").expect("chars");
+        let list = chars.as_list().expect("list");
+        assert_eq!(list.len(), 2);
+    }
+
+    #[test]
+    fn test_reader_dispatch_multiple_chars() {
+        // handler reads further to distinguish sub-syntax.
+        // use read() to inspect raw datums.
+        let ctx = Context::new_standard().expect("context");
+        ctx.evaluate(
+            "(set-reader! #\\j
+               (lambda (port)
+                 (let ((next (read-char port)))
+                   (cond
+                     ((char=? next #\\s) (list 'json (read port)))
+                     ((char=? next #\\w) (list 'jwt (read port)))
+                     (else (error \"unknown #j sub-dispatch\" next))))))",
+        )
+        .expect("set");
+
+        let port = ctx
+            .open_input_port(std::io::Cursor::new(b"#js(1 2 3)"))
+            .expect("port");
+        let json = ctx.read(&port).expect("json");
+        assert_eq!(json.as_list().unwrap()[0], Value::Symbol("json".into()));
+
+        let port2 = ctx
+            .open_input_port(std::io::Cursor::new(b"#jw\"token\""))
+            .expect("port2");
+        let jwt = ctx.read(&port2).expect("jwt");
+        assert_eq!(jwt.as_list().unwrap()[0], Value::Symbol("jwt".into()));
+    }
+
+    #[test]
+    fn test_reader_dispatch_via_import() {
+        // verify (import (tein reader)) works for sandboxed contexts
+        // that need explicit import
+        let ctx = Context::new_standard().expect("context");
+        ctx.evaluate("(import (tein reader))").expect("import");
+        ctx.evaluate("(set-reader! #\\j (lambda (port) 42))")
+            .expect("set-reader");
+        assert_eq!(ctx.evaluate("#j").unwrap(), Value::Integer(42));
+    }
+
+    #[test]
+    fn test_register_reader_from_rust() {
+        let ctx = Context::new_standard().expect("context");
+        let handler = ctx.evaluate("(lambda (port) 42)").expect("handler");
+        ctx.register_reader('j', &handler).expect("register");
+        let result = ctx.evaluate("#j").expect("eval");
+        assert_eq!(result, Value::Integer(42));
+    }
+
+    #[test]
+    fn test_register_reader_reserved_from_rust() {
+        let ctx = Context::new_standard().expect("context");
+        let handler = ctx.evaluate("(lambda (port) 42)").expect("handler");
+        let err = ctx.register_reader('t', &handler).unwrap_err();
+        assert!(format!("{}", err).contains("reserved"));
     }
 }

--- a/tein/src/ffi.rs
+++ b/tein/src/ffi.rs
@@ -187,6 +187,18 @@ unsafe extern "C" {
     // vector construction (via tein shim)
     pub fn tein_sexp_make_vector(ctx: sexp, len: sexp_uint_t, dflt: sexp) -> sexp;
     pub fn tein_sexp_vector_set(vec: sexp, i: sexp_uint_t, val: sexp);
+
+    // custom port creation (via tein shim → chibi io lib)
+    pub fn tein_make_custom_input_port(ctx: sexp, read_proc: sexp) -> sexp;
+    pub fn tein_make_custom_output_port(ctx: sexp, write_proc: sexp) -> sexp;
+
+    // reader dispatch table (# syntax extensions)
+    pub fn tein_reader_dispatch_set(c: c_int, proc: sexp) -> c_int;
+    pub fn tein_reader_dispatch_unset(c: c_int) -> c_int;
+    pub fn tein_reader_dispatch_get(c: c_int) -> sexp;
+    pub fn tein_reader_dispatch_chars(ctx: sexp) -> sexp;
+    pub fn tein_reader_dispatch_clear();
+    pub fn tein_reader_char_is_reserved(c: c_int) -> c_int;
 }
 
 // convenience wrappers that call our shim layer
@@ -618,6 +630,18 @@ impl Drop for GcRoot {
     }
 }
 
+/// create a custom input port backed by a scheme read procedure.
+#[inline]
+pub unsafe fn make_custom_input_port(ctx: sexp, read_proc: sexp) -> sexp {
+    unsafe { tein_make_custom_input_port(ctx, read_proc) }
+}
+
+/// create a custom output port backed by a scheme write procedure.
+#[inline]
+pub unsafe fn make_custom_output_port(ctx: sexp, write_proc: sexp) -> sexp {
+    unsafe { tein_make_custom_output_port(ctx, write_proc) }
+}
+
 /// copy a named binding from src_env to dst_env, searching both direct
 /// bindings and rename bindings (module system). returns true if found.
 #[inline]
@@ -629,4 +653,46 @@ pub unsafe fn env_copy_named(
     name_len: sexp_sint_t,
 ) -> bool {
     unsafe { tein_env_copy_named(ctx, src_env, dst_env, name, name_len) != 0 }
+}
+
+// --- reader dispatch table ---
+
+/// register a reader dispatch handler for `#c` syntax.
+///
+/// returns 0 on success, -1 if the character is reserved, -2 if out of range.
+#[inline]
+pub unsafe fn reader_dispatch_set(c: c_int, proc: sexp) -> c_int {
+    unsafe { tein_reader_dispatch_set(c, proc) }
+}
+
+/// remove a reader dispatch handler for `#c` syntax.
+///
+/// returns 0 on success, -2 if out of range.
+#[inline]
+pub unsafe fn reader_dispatch_unset(c: c_int) -> c_int {
+    unsafe { tein_reader_dispatch_unset(c) }
+}
+
+/// get the reader dispatch handler for `#c`, or SEXP_FALSE if none.
+#[inline]
+pub unsafe fn reader_dispatch_get(c: c_int) -> sexp {
+    unsafe { tein_reader_dispatch_get(c) }
+}
+
+/// return a list of characters with active dispatch handlers.
+#[inline]
+pub unsafe fn reader_dispatch_chars(ctx: sexp) -> sexp {
+    unsafe { tein_reader_dispatch_chars(ctx) }
+}
+
+/// clear all reader dispatch handlers.
+#[inline]
+pub unsafe fn reader_dispatch_clear() {
+    unsafe { tein_reader_dispatch_clear() }
+}
+
+/// check if a character is reserved by r7rs and cannot be dispatched.
+#[inline]
+pub unsafe fn reader_char_is_reserved(c: c_int) -> bool {
+    unsafe { tein_reader_char_is_reserved(c) != 0 }
 }

--- a/tein/src/lib.rs
+++ b/tein/src/lib.rs
@@ -24,6 +24,7 @@ mod error;
 mod ffi;
 pub mod foreign;
 pub mod managed;
+mod port;
 pub mod sandbox;
 mod thread;
 mod timeout;

--- a/tein/src/port.rs
+++ b/tein/src/port.rs
@@ -1,0 +1,57 @@
+//! custom port bridge — rust Read/Write as scheme ports.
+//!
+//! stores rust `Read`/`Write` objects in a per-context map. chibi's custom
+//! port callbacks dispatch through a thread-local pointer to find the
+//! backing reader/writer. same pattern as `ForeignStore`.
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+
+/// stored port object — either a reader or writer.
+enum PortObject {
+    Reader(Box<dyn Read>),
+    Writer(Box<dyn Write>),
+}
+
+/// per-context store for custom port backing objects.
+pub(crate) struct PortStore {
+    ports: HashMap<u64, PortObject>,
+    next_id: u64,
+}
+
+impl PortStore {
+    pub(crate) fn new() -> Self {
+        Self {
+            ports: HashMap::new(),
+            next_id: 1,
+        }
+    }
+
+    pub(crate) fn insert_reader(&mut self, reader: Box<dyn Read>) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.ports.insert(id, PortObject::Reader(reader));
+        id
+    }
+
+    pub(crate) fn insert_writer(&mut self, writer: Box<dyn Write>) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.ports.insert(id, PortObject::Writer(writer));
+        id
+    }
+
+    pub(crate) fn get_reader(&mut self, id: u64) -> Option<&mut dyn Read> {
+        match self.ports.get_mut(&id) {
+            Some(PortObject::Reader(r)) => Some(r.as_mut()),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn get_writer(&mut self, id: u64) -> Option<&mut dyn Write> {
+        match self.ports.get_mut(&id) {
+            Some(PortObject::Writer(w)) => Some(w.as_mut()),
+            _ => None,
+        }
+    }
+}

--- a/tein/vendor/chibi-scheme/lib/tein/reader.scm
+++ b/tein/vendor/chibi-scheme/lib/tein/reader.scm
@@ -1,0 +1,8 @@
+;;; (tein reader) — custom reader dispatch extensions
+;;;
+;;; set-reader!, unset-reader!, reader-dispatch-chars are registered from
+;;; rust as native functions in the context env. this module re-exports them
+;;; for idiomatic r7rs (import (tein reader)) usage.
+;;;
+;;; note: these bindings are already available in the global env for
+;;; standard_env contexts — the import is optional but recommended.

--- a/tein/vendor/chibi-scheme/lib/tein/reader.sld
+++ b/tein/vendor/chibi-scheme/lib/tein/reader.sld
@@ -1,0 +1,3 @@
+(define-library (tein reader)
+  (export set-reader! unset-reader! reader-dispatch-chars)
+  (include "reader.scm"))

--- a/tein/vendor/chibi-scheme/sexp.c
+++ b/tein/vendor/chibi-scheme/sexp.c
@@ -3509,7 +3509,17 @@ sexp sexp_read_raw (sexp ctx, sexp in, sexp *shares) {
     break;
 #endif
   case '#':
-    switch (c1=sexp_read_char(ctx, in)) {
+    c1=sexp_read_char(ctx, in);
+    /* tein patch: check user-registered dispatch before built-in # syntax */
+    {
+      extern sexp tein_reader_dispatch_get(int c);
+      sexp _tein_dispatch = tein_reader_dispatch_get(c1);
+      if (_tein_dispatch != SEXP_FALSE && sexp_applicablep(_tein_dispatch)) {
+        res = sexp_apply1(ctx, _tein_dispatch, in);
+        break;
+      }
+    }
+    switch (c1) {
     case 'b': case 'B':
       res = sexp_read_number(ctx, in, 2, 0); break;
     case 'o': case 'O':

--- a/tein/vendor/chibi-scheme/tein_shim.c
+++ b/tein/vendor/chibi-scheme/tein_shim.c
@@ -308,3 +308,93 @@ int tein_env_copy_named(sexp ctx, sexp src_env, sexp dst_env,
 
     return 0;
 }
+
+// --- custom port creation ---
+// sexp_make_custom_input_port / sexp_make_custom_output_port are defined in
+// lib/chibi/io/port.c (compiled via io.c into chibi_io static lib).
+extern sexp sexp_make_custom_input_port(sexp ctx, sexp self,
+                                         sexp read, sexp seek, sexp close);
+extern sexp sexp_make_custom_output_port(sexp ctx, sexp self,
+                                          sexp write, sexp seek, sexp close);
+
+sexp tein_make_custom_input_port(sexp ctx, sexp read_proc) {
+    return sexp_make_custom_input_port(ctx, SEXP_FALSE, read_proc, SEXP_FALSE, SEXP_FALSE);
+}
+
+sexp tein_make_custom_output_port(sexp ctx, sexp write_proc) {
+    return sexp_make_custom_output_port(ctx, SEXP_FALSE, write_proc, SEXP_FALSE, SEXP_FALSE);
+}
+
+// --- reader dispatch table ---
+// maps ASCII chars to scheme procedures for custom #x syntax.
+// thread-local so each context thread has independent dispatch state.
+
+#define TEIN_READER_DISPATCH_SIZE 128
+
+TEIN_THREAD_LOCAL sexp tein_reader_dispatch[TEIN_READER_DISPATCH_SIZE];
+TEIN_THREAD_LOCAL int tein_reader_dispatch_init = 0;
+
+static void tein_reader_dispatch_ensure_init(void) {
+    if (!tein_reader_dispatch_init) {
+        for (int i = 0; i < TEIN_READER_DISPATCH_SIZE; i++)
+            tein_reader_dispatch[i] = SEXP_FALSE;
+        tein_reader_dispatch_init = 1;
+    }
+}
+
+static int tein_reader_char_reserved(int c) {
+    switch (c) {
+    case 'b': case 'B': case 'o': case 'O': case 'd': case 'D':
+    case 'x': case 'X': case 'e': case 'E': case 'i': case 'I':
+    case 'f': case 'F': case 't': case 'T': case 'u': case 'U':
+    case 'v': case 'V': case 's': case 'S': case 'c': case 'C':
+    case '0': case '1': case '2': case '3': case '4':
+    case '5': case '6': case '7': case '8': case '9':
+    case ';': case '|': case '!': case '\\': case '(': case '\'':
+    case '`': case ',':
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+int tein_reader_char_is_reserved(int c) {
+    return tein_reader_char_reserved(c);
+}
+
+int tein_reader_dispatch_set(int c, sexp proc) {
+    tein_reader_dispatch_ensure_init();
+    if (c < 0 || c >= TEIN_READER_DISPATCH_SIZE) return -2;
+    if (tein_reader_char_reserved(c)) return -1;
+    tein_reader_dispatch[c] = proc;
+    return 0;
+}
+
+int tein_reader_dispatch_unset(int c) {
+    tein_reader_dispatch_ensure_init();
+    if (c < 0 || c >= TEIN_READER_DISPATCH_SIZE) return -2;
+    tein_reader_dispatch[c] = SEXP_FALSE;
+    return 0;
+}
+
+sexp tein_reader_dispatch_get(int c) {
+    tein_reader_dispatch_ensure_init();
+    if (c < 0 || c >= TEIN_READER_DISPATCH_SIZE) return SEXP_FALSE;
+    return tein_reader_dispatch[c];
+}
+
+sexp tein_reader_dispatch_chars(sexp ctx) {
+    tein_reader_dispatch_ensure_init();
+    sexp result = SEXP_NULL;
+    for (int i = TEIN_READER_DISPATCH_SIZE - 1; i >= 0; i--) {
+        if (tein_reader_dispatch[i] != SEXP_FALSE)
+            result = sexp_cons(ctx, sexp_make_character(i), result);
+    }
+    return result;
+}
+
+void tein_reader_dispatch_clear(void) {
+    tein_reader_dispatch_ensure_init();
+    for (int i = 0; i < TEIN_READER_DISPATCH_SIZE; i++)
+        tein_reader_dispatch[i] = SEXP_FALSE;
+}


### PR DESCRIPTION
custom ports: bridge rust Read/Write to scheme input/output ports via
PortStore + thread-local trampoline (same pattern as ForeignStore).
open_input_port, open_output_port, read, evaluate_port.

reader dispatch: extend chibi's # reader with user-defined handlers
via C-level dispatch table. patched sexp.c checks tein_reader_dispatch
before hardcoded # switch. set-reader!, unset-reader!,
reader-dispatch-chars registered as native fns for standard env.
Context::register_reader() rust convenience API. (tein reader) VFS
module for idiomatic imports. reserved r7rs chars protected, dispatch
table cleared on context drop.

183 lib tests (was 165), 14 doc-tests (was 9). clippy clean.
