### PR TITLE
fix: alist Serialize emits maps, not arrays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +242,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +306,7 @@ name = "tein-sexp"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -482,3 +502,9 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/tein-sexp/Cargo.toml
+++ b/tein-sexp/Cargo.toml
@@ -16,3 +16,6 @@ serde = ["dep:serde"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"], optional = true }
+
+[dev-dependencies]
+serde_json = "1"

--- a/tein-sexp/src/ast.rs
+++ b/tein-sexp/src/ast.rs
@@ -294,6 +294,26 @@ impl Sexp {
         matches!(self.kind, SexpKind::Nil)
     }
 
+    /// returns true if this list looks like an association list.
+    ///
+    /// an alist is a non-empty list where every element is a dotted pair `(key . val)`
+    /// with a symbol or string key. returns false for non-list values and empty lists.
+    ///
+    /// used by the serde `Serialize` impl to emit alists as maps rather than sequences,
+    /// ensuring round-trip fidelity with map-based formats like JSON.
+    pub fn is_alist(&self) -> bool {
+        let items = match &self.kind {
+            SexpKind::List(items) if !items.is_empty() => items,
+            _ => return false,
+        };
+        items.iter().all(|item| match &item.kind {
+            SexpKind::DottedList(keys, _) if keys.len() == 1 => {
+                matches!(&keys[0].kind, SexpKind::Symbol(_) | SexpKind::String(_))
+            }
+            _ => false,
+        })
+    }
+
     /// extract as bignum string, if this is a `Bignum`
     pub fn as_bignum(&self) -> Option<&str> {
         match &self.kind {
@@ -565,6 +585,16 @@ impl serde::Serialize for Sexp {
             SexpKind::Boolean(b) => serializer.serialize_bool(*b),
             SexpKind::Char(c) => serializer.serialize_char(*c),
             SexpKind::Nil => serializer.serialize_unit(),
+            SexpKind::List(items) if self.is_alist() => {
+                use serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(Some(items.len()))?;
+                for item in items {
+                    // is_alist guarantees: DottedList with exactly one symbol/string key
+                    let (keys, tail) = item.as_dotted_list().unwrap();
+                    map.serialize_entry(&keys[0], tail)?;
+                }
+                map.end()
+            }
             SexpKind::List(items) => {
                 let mut seq = serializer.serialize_seq(Some(items.len()))?;
                 for item in items {
@@ -1008,5 +1038,142 @@ mod tests {
             Sexp::rational(Sexp::integer(1), Sexp::integer(3)),
         );
         assert_eq!(Sexp::bytevector(vec![1, 2]), Sexp::bytevector(vec![1, 2]));
+    }
+
+    // --- is_alist tests ---
+
+    #[test]
+    fn is_alist_symbol_keys() {
+        let alist = Sexp::list(vec![
+            Sexp::dotted_list(vec![Sexp::symbol("a")], Sexp::integer(1)),
+            Sexp::dotted_list(vec![Sexp::symbol("b")], Sexp::integer(2)),
+        ]);
+        assert!(alist.is_alist());
+    }
+
+    #[test]
+    fn is_alist_string_keys() {
+        let alist = Sexp::list(vec![Sexp::dotted_list(
+            vec![Sexp::string("name")],
+            Sexp::string("alice"),
+        )]);
+        assert!(alist.is_alist());
+    }
+
+    #[test]
+    fn is_alist_empty_list() {
+        assert!(!Sexp::nil().is_alist());
+    }
+
+    #[test]
+    fn is_alist_plain_list() {
+        let plain = Sexp::list(vec![Sexp::integer(1), Sexp::integer(2)]);
+        assert!(!plain.is_alist());
+    }
+
+    #[test]
+    fn is_alist_non_list() {
+        assert!(!Sexp::integer(42).is_alist());
+        assert!(!Sexp::string("hi").is_alist());
+    }
+
+    #[test]
+    fn is_alist_mixed_not_alist() {
+        // one proper entry, one plain integer — not an alist
+        let mixed = Sexp::list(vec![
+            Sexp::dotted_list(vec![Sexp::symbol("a")], Sexp::integer(1)),
+            Sexp::integer(2),
+        ]);
+        assert!(!mixed.is_alist());
+    }
+
+    #[test]
+    fn is_alist_integer_key_not_alist() {
+        // dotted pair with non-symbol/string key
+        let bad = Sexp::list(vec![Sexp::dotted_list(
+            vec![Sexp::integer(1)],
+            Sexp::integer(2),
+        )]);
+        assert!(!bad.is_alist());
+    }
+}
+
+/// JSON round-trip tests proving alists serialize as objects, not arrays.
+///
+/// requires the `serde` feature and the `serde_json` dev-dependency.
+#[cfg(all(test, feature = "serde"))]
+mod json_tests {
+    use super::*;
+
+    #[test]
+    fn alist_round_trips_as_json_object() {
+        // alist → json object → alist
+        let alist = Sexp::list(vec![
+            Sexp::dotted_list(vec![Sexp::string("name")], Sexp::string("tein")),
+            Sexp::dotted_list(vec![Sexp::string("version")], Sexp::integer(1)),
+        ]);
+        let json = serde_json::to_string(&alist).unwrap();
+        assert_eq!(json, r#"{"name":"tein","version":1}"#);
+        let restored: Sexp = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, alist);
+    }
+
+    #[test]
+    fn plain_list_round_trips_as_json_array() {
+        let list = Sexp::list(vec![Sexp::integer(1), Sexp::integer(2), Sexp::integer(3)]);
+        let json = serde_json::to_string(&list).unwrap();
+        assert_eq!(json, "[1,2,3]");
+        let restored: Sexp = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, list);
+    }
+
+    #[test]
+    fn nested_object_round_trip() {
+        let inner = Sexp::list(vec![Sexp::dotted_list(
+            vec![Sexp::string("x")],
+            Sexp::integer(10),
+        )]);
+        let outer = Sexp::list(vec![Sexp::dotted_list(vec![Sexp::string("nested")], inner)]);
+        let json = serde_json::to_string(&outer).unwrap();
+        assert_eq!(json, r#"{"nested":{"x":10}}"#);
+        let restored: Sexp = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, outer);
+    }
+
+    #[test]
+    fn json_null_becomes_nil() {
+        let sexp: Sexp = serde_json::from_str("null").unwrap();
+        assert!(sexp.is_nil());
+    }
+
+    #[test]
+    fn json_boolean_round_trip() {
+        let t: Sexp = serde_json::from_str("true").unwrap();
+        assert_eq!(t, Sexp::boolean(true));
+        assert_eq!(serde_json::to_string(&t).unwrap(), "true");
+    }
+
+    #[test]
+    fn json_empty_object_becomes_nil() {
+        // {} has no entries → empty alist → Nil (via Sexp::list(vec![]))
+        let sexp: Sexp = serde_json::from_str("{}").unwrap();
+        assert!(sexp.is_nil());
+    }
+
+    #[test]
+    fn json_empty_array_becomes_nil() {
+        let sexp: Sexp = serde_json::from_str("[]").unwrap();
+        assert!(sexp.is_nil());
+    }
+
+    #[test]
+    fn symbol_keyed_alist_as_json_object() {
+        // symbol keys also serialize as JSON object (symbols → strings in JSON)
+        let alist = Sexp::list(vec![Sexp::dotted_list(
+            vec![Sexp::symbol("key")],
+            Sexp::integer(42),
+        )]);
+        let json = serde_json::to_string(&alist).unwrap();
+        assert_eq!(json, r#"{"key":42}"#);
     }
 }

--- a/tein-sexp/src/serde/de.rs
+++ b/tein-sexp/src/serde/de.rs
@@ -65,8 +65,8 @@ impl<'de, 'a> de::Deserializer<'de> for SexpDeserializer<'a> {
             SexpKind::Char(c) => visitor.visit_char(*c),
             SexpKind::Nil => visitor.visit_unit(),
             SexpKind::List(items) => {
-                // heuristic: if all items are dotted pairs with symbol car, treat as map
-                if is_alist(items) {
+                // heuristic: if all items are dotted pairs with symbol/string key, treat as map
+                if self.sexp.is_alist() {
                     visitor.visit_map(AlistMapAccess::new(items))
                 } else {
                     visitor.visit_seq(SexpSeqAccess::new(items))
@@ -79,6 +79,26 @@ impl<'de, 'a> de::Deserializer<'de> for SexpDeserializer<'a> {
                 visitor.visit_seq(SexpSeqAccess::new_owned(all))
             }
             SexpKind::Vector(items) => visitor.visit_seq(SexpSeqAccess::new(items)),
+            // numeric tower: bignums serialize as strings, rational/complex as maps
+            SexpKind::Bignum(s) => visitor.visit_string(s.clone()),
+            SexpKind::Rational(n, d) => {
+                let entries = vec![
+                    Sexp::dotted_list(vec![Sexp::string("numerator")], *n.clone()),
+                    Sexp::dotted_list(vec![Sexp::string("denominator")], *d.clone()),
+                ];
+                visitor.visit_map(OwnedAlistMapAccess::new(entries))
+            }
+            SexpKind::Complex(r, i) => {
+                let entries = vec![
+                    Sexp::dotted_list(vec![Sexp::string("real")], *r.clone()),
+                    Sexp::dotted_list(vec![Sexp::string("imag")], *i.clone()),
+                ];
+                visitor.visit_map(OwnedAlistMapAccess::new(entries))
+            }
+            SexpKind::Bytevector(bytes) => {
+                let items: Vec<Sexp> = bytes.iter().map(|&b| Sexp::integer(b as i64)).collect();
+                visitor.visit_seq(SexpSeqAccess::new_owned(items))
+            }
         }
     }
 
@@ -390,6 +410,42 @@ impl<'de, 'a> de::MapAccess<'de> for AlistMapAccess<'a> {
     }
 }
 
+/// owned variant of [`AlistMapAccess`] for synthetic alist entries (e.g. rational/complex).
+struct OwnedAlistMapAccess {
+    items: Vec<Sexp>,
+    index: usize,
+}
+
+impl OwnedAlistMapAccess {
+    fn new(items: Vec<Sexp>) -> Self {
+        Self { items, index: 0 }
+    }
+}
+
+impl<'de> de::MapAccess<'de> for OwnedAlistMapAccess {
+    type Error = ParseError;
+
+    fn next_key_seed<K: de::DeserializeSeed<'de>>(
+        &mut self,
+        seed: K,
+    ) -> Result<Option<K::Value>, ParseError> {
+        if self.index >= self.items.len() {
+            return Ok(None);
+        }
+        let key = alist_key(&self.items[self.index])?;
+        seed.deserialize(SexpDeserializer { sexp: key }).map(Some)
+    }
+
+    fn next_value_seed<V: de::DeserializeSeed<'de>>(
+        &mut self,
+        seed: V,
+    ) -> Result<V::Value, ParseError> {
+        let val = alist_value(&self.items[self.index])?;
+        self.index += 1;
+        seed.deserialize(SexpDeserializer { sexp: val })
+    }
+}
+
 /// extract the key from an alist entry (dotted pair)
 fn alist_key(entry: &Sexp) -> Result<&Sexp, ParseError> {
     match &entry.kind {
@@ -412,22 +468,6 @@ fn alist_value(entry: &Sexp) -> Result<&Sexp, ParseError> {
             entry.span,
         )),
     }
-}
-
-/// heuristic: check if a list looks like an alist (all dotted pairs with symbol or string keys)
-///
-/// accepts both symbol keys (e.g. from struct serialisation) and string keys (e.g. from
-/// `BTreeMap<String, V>`), so `deserialize_any` can detect both as maps rather than sequences.
-fn is_alist(items: &[Sexp]) -> bool {
-    if items.is_empty() {
-        return false;
-    }
-    items.iter().all(|item| match &item.kind {
-        SexpKind::DottedList(keys, _) if keys.len() == 1 => {
-            matches!(&keys[0].kind, SexpKind::Symbol(_) | SexpKind::String(_))
-        }
-        _ => false,
-    })
 }
 
 // --- enum access ---
@@ -595,7 +635,7 @@ mod tests {
 
     #[test]
     fn deserialize_empty_vec() {
-        assert_eq!(from_str::<Vec<i32>>("()").unwrap(), vec![]);
+        assert_eq!(from_str::<Vec<i32>>("()").unwrap(), Vec::<i32>::new());
     }
 
     #[test]


### PR DESCRIPTION
the Serialize impl for List flattened alists into sequences, breaking
round-trip fidelity with map-based formats like JSON. now detects alists
via is_alist() and emits serialize_map instead.

also:
- add Sexp::is_alist() public method (single source of truth)
- remove standalone is_alist() from de.rs (use method instead)
- add missing Deserialize arms for Bignum, Rational, Complex, Bytevector
- add OwnedAlistMapAccess for synthetic alist entries
- add serde_json dev-dependency for JSON round-trip tests
- fix vec![] type ambiguity with serde_json's PartialEq blanket impl

closes #36 prerequisite: tein-sexp alist serde round-trip
